### PR TITLE
Added virtual keywork to totalSupply() function

### DIFF
--- a/contracts/WithLimitedSupply.sol
+++ b/contracts/WithLimitedSupply.sol
@@ -25,7 +25,7 @@ abstract contract WithLimitedSupply {
 
     /// @dev Get the max Supply
     /// @return the maximum token count
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view virtual returns (uint256) {
         return _totalSupply;
     }
 


### PR DESCRIPTION
When the contract inherits from this one or any other than inherits from this and uses `ERC721Enumerable` from openzeppelin, the `totalSupply` function needs to be override and that can not be done without the virtual keyword