### PR TITLE
Bugfix: Undeclared balanceOf()

### DIFF
--- a/contracts/WithERC20Withdrawals.sol
+++ b/contracts/WithERC20Withdrawals.sol
@@ -13,6 +13,6 @@ abstract contract WithERC20Withdrawals is Ownable
     /// @dev only the owner can withdraw
     /// @param token contract to withdraw
     function withdrawERC20Token(address token) public onlyOwner {
-        IERC20(token).safeTransfer(msg.sender, balanceOf(address(this)));
+        IERC20(token).safeTransfer(msg.sender, IERC20(token).balanceOf(address(this)));
     }
 }


### PR DESCRIPTION
Hi, it seems that balanceOf() is not properly declared and ```npm test``` command fails.

```
DeclarationError: Undeclared identifier.
  --> contracts/WithERC20Withdrawals.sol:16:48:
   |
16 |         IERC20(token).safeTransfer(msg.sender, balanceOf(address(this)));
   |                                                ^^^^^^^^^


Error HH600: Compilation failed
```

Can you take a look at it?